### PR TITLE
エラーを出して少し親切に

### DIFF
--- a/R/inline_citation.R
+++ b/R/inline_citation.R
@@ -24,7 +24,7 @@ inLineCitation <- function(st, bib.df) {
   ### citation cheker
   checksum <- bib.df$BIBTEXKEY %in% str_replace(item,pattern = "@",replacement = "") %>% sum
   if(checksum == 0 ){
-    stop(paste("引用",item,"がbibファイルにありません"))
+    stop(paste("Citation key",item," does not exsist on your bib file."))
   }
   
   loc <- st %>% str_locate(item)

--- a/R/inline_citation.R
+++ b/R/inline_citation.R
@@ -21,13 +21,18 @@
 #'
 inLineCitation <- function(st, bib.df) {
   item <- st %>% str_extract(pattern = "@[\\[a-zA-Z0-9-_\\.\\p{Hiragana}\\p{Katakana}\\p{Han}]*")
+  ### citation cheker
+  checksum <- bib.df$BIBTEXKEY %in% str_replace(item,pattern = "@",replacement = "") %>% sum
+  if(checksum == 0 ){
+    stop(paste("引用",item,"がbibファイルにありません"))
+  }
+  
   loc <- st %>% str_locate(item)
   loc <- loc[1] - 1
   tp <- FALSE
   if (loc > 0) {
     tp <- str_sub(st, loc, loc) %>% str_detect(pattern = "\\[")
   }
-
   tmp.df <- data.frame()
   if (tp) {
     ### citation on the end of line


### PR DESCRIPTION
引用は合ってるはずなのに，エラーが出て止まってしまう，でもどこにエラーなの・・・・？

そんなことありませんか。私はあります（ありました）。
引用キーがBibファイルにない場合，エラーを出して教えてあげるようにしました。

ちなみに@keyの後ろにスペースがないというよくあるミスでした。
たとえば↑の書き方だと，引用符が「@keyの後ろに・・・」と末尾まで行きます。