### PR TITLE
脚注と引用が同じ行に入っているとwhile文を抜け出せなかったバグを修正

### DIFF
--- a/R/inline_citation.R
+++ b/R/inline_citation.R
@@ -36,8 +36,6 @@ inLineCitation <- function(st, bib.df) {
   tmp.df <- data.frame()
   if (tp) {
     ### citation on the end of line
-    ##### retake citation key
-    item <- st %>% str_extract(pattern = "\\[.*?\\]")
     ##### citaton data frame
     tmp.df <- item %>%
       str_extract_all(pattern = "@[a-zA-Z0-9-_\\.\\p{Hiragana}\\p{Katakana}\\p{Han}]*", simplify = T) %>%


### PR DESCRIPTION
卒論生のデータで発覚したバグです