### PR TITLE
省略した名前の前の後ろに半角スペースを

### DIFF
--- a/R/bib_to_df.R
+++ b/R/bib_to_df.R
@@ -37,7 +37,7 @@
 #' @examples
 #' # bib_to_DF(Rmd_file = "RmdFileName",Bib_file = "BibFileName")
 #' @export
-bib_to_DF <- function(Rmd_file, Bib_file, list_ampersand = F, cite_ampersand = F, underline = F) {
+bib_to_DF <- function(Rmd_file, Bib_file, list_ampersand = T, cite_ampersand = F, underline = F) {
   # check argument
   if (missing(Rmd_file)) {
     stop("Please set the name of RMarkdown file")

--- a/R/jpa_bib_functions.R
+++ b/R/jpa_bib_functions.R
@@ -106,8 +106,8 @@ print_EName <- function(st, ampersand = T, switchFLG = FALSE) {
   st %>%
     rowwise() %>%
     mutate(
-      initial_first = if_else(.data$exFLG, "", paste0(.data$initial_first, ".")),
-      initial_middle = if_else(.data$exFLG, "", paste0(.data$initial_middle, ".")),
+      initial_first = if_else(.data$exFLG, "", paste0(.data$initial_first, ". ")),
+      initial_middle = if_else(.data$exFLG, "", paste0(.data$initial_middle, ". ")),
       initial_name = paste0(.data$initial_first, if_else(.data$initial_middle == "NA.", "", .data$initial_middle)),
       pName = if_else(switchFLG,
         paste(.data$initial_name, .data$last_name),

--- a/R/jpa_cite.R
+++ b/R/jpa_cite.R
@@ -61,7 +61,7 @@ value_extractor <- function(string) {
 #' # jpa_cite(Rmd_file = "RmdFileName",Bib_file = "BibFileName")
 #' @export
 jpa_cite <- function(Rmd_file, Bib_file) {
-  bib.df <- bib_to_DF(Rmd_file, Bib_file, list_ampersand = F, cite_ampersand = F, underline = F)
+  bib.df <- bib_to_DF(Rmd_file, Bib_file, list_ampersand = T, cite_ampersand = F , underline = F)
   # Rewrite citation in the text. -------------------------------------------------------------------
   ## get original file
   tmpfile <- readLines(Rmd_file, warn = F)


### PR DESCRIPTION
ゼミ生からの指摘で，引用文献リストの最後が＆記号になること，頭文字の後に半角スペースを入れることに対応しました